### PR TITLE
Typo in closeSocketHandler method name & Intellij IDEA support in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.classpath
 /.project
 /.settings/
+/.idea/*
+*.iml

--- a/src/main/java/net/logstash/logging/handler/SocketHandler.java
+++ b/src/main/java/net/logstash/logging/handler/SocketHandler.java
@@ -194,7 +194,7 @@ public class SocketHandler extends ExtHandler {
     } else {
       reportError("Error writing log message", e, ErrorManager.WRITE_FAILURE);
     }
-    closeSockerHandler();
+    closeSocketHandler();
   }
 
   @Override
@@ -207,11 +207,11 @@ public class SocketHandler extends ExtHandler {
 
   @Override
   public void close() {
-    closeSockerHandler();
+    closeSocketHandler();
     super.close();
   }
 
-  private void closeSockerHandler() {
+  private void closeSocketHandler() {
     checkAccess(this);
     synchronized (this) {
       safeClose(writer);


### PR DESCRIPTION
- Method _closeSocketHandler_ contained typo, actually was _closeSockerHandler_. Fixed this.
- Added /.idea folder and .iml files to .gitignore file
